### PR TITLE
deprecated JSONField

### DIFF
--- a/src/djpaypal/fields.py
+++ b/src/djpaypal/fields.py
@@ -1,4 +1,7 @@
-from django.db.models import JSONField
+try:
+    from django.db.models import JSONField
+except ImportError:
+    from django.contrib.postgres.fields import JSONField
 
 
 __all__ = ("CurrencyAmountField", "JSONField")

--- a/src/djpaypal/fields.py
+++ b/src/djpaypal/fields.py
@@ -1,4 +1,4 @@
-from django.contrib.postgres.fields import JSONField
+from django.db.models import JSONField
 
 
 __all__ = ("CurrencyAmountField", "JSONField")


### PR DESCRIPTION
can we substitute django.contrib.postgres.fields.JSONField fro
django.db.models.JSONField without breaking backwards compatability?